### PR TITLE
Fix scroll to top score page

### DIFF
--- a/src/components/QuizAnswer/QuizAnswerScore/QuizAnswerScore.jsx
+++ b/src/components/QuizAnswer/QuizAnswerScore/QuizAnswerScore.jsx
@@ -1,4 +1,4 @@
-import React from "react";
+import React, { useEffect } from "react";
 import PropTypes from "prop-types";
 import { Link } from "react-router-dom";
 import { FontAwesomeIcon } from "@fortawesome/react-fontawesome";
@@ -14,6 +14,9 @@ function removeHttp(url) {
 }
 
 const QuizAnswerScore = ({ result }) => {
+  useEffect(() => {
+    window.scrollTo(0, 0);
+  }, []);
   return (
     <>
       <h1 className="quizAnswerScore__quizTitle">

--- a/src/pages/AnswerQuiz/AnswerQuiz.jsx
+++ b/src/pages/AnswerQuiz/AnswerQuiz.jsx
@@ -1,4 +1,4 @@
-import React, { useState, useEffect } from "react";
+import React, { useState } from "react";
 import { useLocation } from "react-router-dom";
 import { useFormik } from "formik";
 import "./AnswerQuiz.css";
@@ -18,9 +18,6 @@ const AnswerQuiz = () => {
   const { questions } = from;
   const { answerQuiz, result } = useAnswerQuiz();
   const [questionErrors, setQuestionErrors] = useState(null);
-  useEffect(() => {
-    window.scrollTo(0, 0);
-  }, [result.data]);
 
   const formik = useFormik({
     initialValues: {},


### PR DESCRIPTION
When the user now arrives on the Quiz Answer Score Page, he will automatically arrive on the top of the page and see immediately his score. (Before he arrived at the middle of the page and had to manually scroll up the page to see his score)
![Screenshot 2023-01-23 at 23 18 46](https://user-images.githubusercontent.com/69986868/214162748-30842961-656a-4690-b260-3eaa45208b4b.png)
